### PR TITLE
Implement decoder

### DIFF
--- a/Pkl/Decoder/CollectionDecoder.cs
+++ b/Pkl/Decoder/CollectionDecoder.cs
@@ -1,0 +1,27 @@
+using MessagePack;
+
+namespace Pkl.Decoding;
+
+public partial class Decoder
+{
+    // TODO maybe support collection types other than arrays
+    private Array DecodeCollection(ref MessagePackReader reader, Type targetType)
+    {
+        var len = reader.ReadArrayHeader();
+        var elementType = targetType.GetElementType();
+
+        if (elementType is null)
+        {
+            throw new Exception(nameof(targetType) + "must be an array with an element type");
+        }
+
+        var arr = Array.CreateInstance(elementType, len);
+        for (int i = 0; i < len; i++)
+        {
+            var value = DecodeAny(ref reader, elementType);
+            arr.SetValue(value, i);
+        }
+
+        return arr;
+    }
+}

--- a/Pkl/Decoder/Decoder.cs
+++ b/Pkl/Decoder/Decoder.cs
@@ -2,12 +2,74 @@ using MessagePack;
 
 namespace Pkl.Decoding;
 
-public class Decoder
+public partial class Decoder
 {
-    public object Decode(byte[] input)
+    public T Decode<T>(byte[] input) where T : notnull
     {
         var reader = new MessagePackReader(input);
-        // TODO
-        return null!;
+        
+        return DecodeAny<T>(ref reader);
+    }
+
+    private T DecodeAny<T>(ref MessagePackReader reader) where T : notnull
+    {
+        var value = DecodeAny(ref reader, typeof(T));
+
+        if (value is T valueT)
+        {
+            return valueT;
+        }
+
+        throw new Exception("Invalid type parameter " + nameof(T));
+    }
+
+    private object? DecodeAny(ref MessagePackReader reader, Type targetType)
+    {
+        var messagePackType = reader.NextMessagePackType;
+        var code = reader.NextCode;
+
+        switch (messagePackType)
+        {
+            case MessagePackType.Map:
+                return ReadMap(ref reader);
+            case MessagePackType.Array:
+                return ReadPklObject(ref reader, targetType);
+            case MessagePackType.String:
+                return reader.ReadString()!;
+            case MessagePackType.Nil:
+                reader.Skip();
+                return null;
+            // Primitives
+            case MessagePackType.Boolean:
+                return reader.ReadBoolean();
+            case MessagePackType.Integer:
+                // TODO differentiate integer types
+                if (code is MessagePackCode.Int8 
+                    or MessagePackCode.Int16
+                    or MessagePackCode.UInt8
+                    or MessagePackCode.UInt16
+                    or (>= MessagePackCode.MinFixInt and <= MessagePackCode.MaxFixInt)
+                    or (>= MessagePackCode.MinNegativeFixInt and <= MessagePackCode.MaxNegativeFixInt))
+                {
+                    return reader.ReadInt16();
+                }
+
+                if (code is MessagePackCode.Int32 or MessagePackCode.UInt32)
+                {
+                    return reader.ReadInt32();
+                }
+
+                if (code is MessagePackCode.Int64 or MessagePackCode.UInt64)
+                {
+                    return reader.ReadInt64();
+                }
+                
+                throw new Exception("Invalid integer code " + code);
+            case MessagePackType.Float:
+                // TODO differentiate floats and doubles
+                return reader.ReadDouble();
+            default:
+                throw new Exception("Unsupported messagepackcode");
+        }
     }
 }

--- a/Pkl/Decoder/Decoder.cs
+++ b/Pkl/Decoder/Decoder.cs
@@ -31,7 +31,7 @@ public partial class Decoder
         switch (messagePackType)
         {
             case MessagePackType.Map:
-                return ReadMap(ref reader);
+                return ReadMap(ref reader, targetType);
             case MessagePackType.Array:
                 return ReadPklObject(ref reader, targetType);
             case MessagePackType.String:

--- a/Pkl/Decoder/MapDecoder.cs
+++ b/Pkl/Decoder/MapDecoder.cs
@@ -1,0 +1,33 @@
+using MessagePack;
+
+namespace Pkl.Decoding;
+
+public partial class Decoder
+{
+    private object ReadMap(ref MessagePackReader reader)
+    {
+        var code = DecodePklObjectCode(ref reader);
+
+        if (code == PklTypeCode.CodeSet)
+        {
+            return DecodeSet(ref reader);
+        }
+
+        if (code != PklTypeCode.CodeMap && code != PklTypeCode.CodeMapping)
+        {
+            throw new Exception("Invalid map code " + code);
+        }
+
+        return DecodeMap(ref reader);
+    }
+
+    private object DecodeSet(ref MessagePackReader reader)
+    {
+        throw new NotImplementedException();
+    }
+
+    private object DecodeMap(ref MessagePackReader reader)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Pkl/Decoder/MapDecoder.cs
+++ b/Pkl/Decoder/MapDecoder.cs
@@ -4,13 +4,13 @@ namespace Pkl.Decoding;
 
 public partial class Decoder
 {
-    private object ReadMap(ref MessagePackReader reader)
+    private object ReadMap(ref MessagePackReader reader, Type targetType)
     {
         var code = DecodePklObjectCode(ref reader);
 
         if (code == PklTypeCode.CodeSet)
         {
-            return DecodeSet(ref reader);
+            return DecodeSet(ref reader, targetType);
         }
 
         if (code != PklTypeCode.CodeMap && code != PklTypeCode.CodeMapping)
@@ -18,16 +18,55 @@ public partial class Decoder
             throw new Exception("Invalid map code " + code);
         }
 
-        return DecodeMap(ref reader);
+        return DecodeMap(ref reader, targetType);
     }
 
-    private object DecodeSet(ref MessagePackReader reader)
+    private object DecodeSet(ref MessagePackReader reader, Type targetType)
     {
-        throw new NotImplementedException();
+        var genericArguments = targetType.GetGenericArguments();
+        if (genericArguments.Length != 1)
+        {
+            throw new Exception("Invalid generic arguments for set type");
+        }
+
+        var len = reader.ReadArrayHeader();
+        var hashSetType = typeof(HashSet<>).MakeGenericType(genericArguments[0]);
+        var hashSet = Activator.CreateInstance(hashSetType, len);
+
+        var invokeParams = new object[1];
+        for (int i = 0; i < len; i++)
+        {
+            var item = DecodeAny(ref reader, genericArguments[0]);
+            invokeParams[0] = item!;
+            hashSetType.GetMethod(nameof(HashSet<object>.Add))!.Invoke(hashSet, invokeParams);
+        }
+
+        return hashSet!;
     }
 
-    private object DecodeMap(ref MessagePackReader reader)
+    private object DecodeMap(ref MessagePackReader reader, Type targetType)
     {
-        throw new NotImplementedException();
+        var genericArguments = targetType.GetGenericArguments();
+        if (genericArguments.Length != 2)
+        {
+            throw new Exception("Invalid generic arguments for map type");
+        }
+
+        var dictionaryType = typeof(Dictionary<,>).MakeGenericType(genericArguments);
+        var dictionary = Activator.CreateInstance(dictionaryType);
+
+        var len = reader.ReadMapHeader();
+        var invokeParams = new object[2];
+        for (int i = 0; i < len; i++)
+        {
+            var key = DecodeAny(ref reader, genericArguments[0]);
+            var value = DecodeAny(ref reader, genericArguments[1]);
+
+            invokeParams[0] = key!;
+            invokeParams[1] = value!;
+            dictionaryType.GetMethod(nameof(Dictionary<object, object>.Add))!.Invoke(dictionary, invokeParams);
+        }
+
+        return dictionary!;
     }
 }

--- a/Pkl/Decoder/PklObjectDecoder.cs
+++ b/Pkl/Decoder/PklObjectDecoder.cs
@@ -1,0 +1,208 @@
+using MessagePack;
+using Pkl.PklTypes;
+using System.Dynamic;
+using System.Text.RegularExpressions;
+
+namespace Pkl.Decoding;
+
+public partial class Decoder
+{
+    private object? ReadPklObject(ref MessagePackReader reader, Type targetType)
+    {
+        var code = DecodePklObjectCode(ref reader);
+
+        return code switch
+        {
+            PklTypeCode.CodeObject => DecodeObject(ref reader, targetType),
+            PklTypeCode.CodeList or PklTypeCode.CodeListing => DecodeCollection(ref reader, targetType),
+            PklTypeCode.CodeDataSize => DecodeDataSize(ref reader),
+            PklTypeCode.CodeDuration => DecodeDuration(ref reader),
+            PklTypeCode.CodePair => DecodePair(ref reader, targetType),
+            PklTypeCode.CodeIntSeq => DecodeIntSeq(ref reader),
+            PklTypeCode.CodeRegex => DecodeRegex(ref reader),
+            PklTypeCode.CodeClass => DecodeClass(),
+            PklTypeCode.CodeTypeAlias => DecodeTypeAlias(),
+
+            _ => throw new Exception(nameof(code) + " is out of range"),
+        };
+    }
+
+    private PklTypeCode DecodePklObjectCode(ref MessagePackReader reader)
+    {
+        var _ = reader.ReadArrayHeader();
+        var code = reader.ReadInt32();
+
+        return (PklTypeCode)code;
+    }
+
+    private object? DecodeObject(ref MessagePackReader reader, Type targetType)
+    {
+        var name = reader.ReadString();
+        var moduleUri = reader.ReadString();
+
+        var isDynamic = targetType == typeof(object)
+            || moduleUri == "pkl:base" && name == "Dynamic";
+        if (isDynamic)
+        {
+            return DecodeDynamic(ref reader, targetType);
+        }
+
+        var instance = Activator.CreateInstance(targetType);
+        var len = reader.ReadArrayHeader();
+        for (int i = 0; i < len; i++)
+        {
+            var code = DecodePklObjectCode(ref reader);
+
+            if (code != PklTypeCode.CodeObjectMemberProperty)
+            {
+                continue;
+            }
+
+            var propertyName = reader.ReadString()!;
+            propertyName =  ToPropertyName(propertyName);
+            var property = targetType.GetProperty(propertyName);
+            if (property is null)
+            {
+                continue;
+            }
+
+            var propertyType = property.PropertyType;
+            var propertyValue = DecodeAny(ref reader, propertyType);
+            property.SetValue(instance, propertyValue);
+        }
+
+        return instance;
+    }
+
+    private dynamic DecodeDynamic(ref MessagePackReader reader, Type targetType)
+    {
+        var len = reader.ReadArrayHeader();
+        var instance = new ExpandoObject() as IDictionary<string, object?>;
+        for (int i = 0; i < len; i++)
+        {
+            var code = DecodePklObjectCode(ref reader);
+
+            if (code != PklTypeCode.CodeObjectMemberProperty)
+            {
+                continue;
+            }
+
+            var propertyName = reader.ReadString()!;
+            propertyName = ToPropertyName(propertyName);
+            var propertyValue = DecodeAny(ref reader, typeof(object));
+
+            instance.Add(propertyName, propertyValue);
+        }
+
+        return instance;
+    }
+
+    private DataSize DecodeDataSize(ref MessagePackReader reader)
+    {
+        var value = reader.ReadDouble();
+        var unitString = reader.ReadString();
+        var unit = DataSizeUnitFromString(unitString);
+
+        return new DataSize(unit, value);
+    }
+
+    private DataSizeUnit DataSizeUnitFromString(string? unitString)
+    {
+        return unitString?.ToLower() switch
+        {
+            "b" => DataSizeUnit.Bytes,
+            "kb" => DataSizeUnit.Kilobytes,
+            "kib" => DataSizeUnit.Kibibytes,
+            "mb" => DataSizeUnit.Megabytes,
+            "mib" => DataSizeUnit.Mebibytes,
+            "gb" => DataSizeUnit.Gigabytes,
+            "gib" => DataSizeUnit.Gibibytes,
+            "tb" => DataSizeUnit.Terabytes,
+            "tib" => DataSizeUnit.Tebibytes,
+            "pb" => DataSizeUnit.Petabytes,
+            "pib" => DataSizeUnit.Pebibytes,
+            _ => throw new ArgumentOutOfRangeException(nameof(unitString))
+        };
+    }
+
+    private Duration DecodeDuration(ref MessagePackReader reader)
+    {
+        var value = reader.ReadDouble();
+        var unitString = reader.ReadString();
+        var unit = DurationUnitFromString(unitString);
+
+        return new Duration(unit, value);
+    }
+
+    private DurationUnit DurationUnitFromString(string? unitString)
+    {
+        return unitString switch
+        {
+            "ns" => DurationUnit.Nanosecond,
+            "us" => DurationUnit.Microsecond,
+            "ms" => DurationUnit.Millisecond,
+            "s" => DurationUnit.Second,
+            "min" => DurationUnit.Minute,
+            "h" => DurationUnit.Hour,
+            "d" => DurationUnit.Day,
+
+            _ => throw new ArgumentOutOfRangeException(nameof(unitString)),
+        };
+    }
+
+    private object? DecodePair(ref MessagePackReader reader, Type targetType)
+    {
+        var genericArguments = targetType.GetGenericArguments();
+        var firstType = genericArguments.First();
+        var secondType = genericArguments.Last();
+
+        var first = DecodeAny(ref reader, firstType);
+        var second = DecodeAny(ref reader, secondType);
+
+        var tupleType = typeof(ValueTuple<,>).MakeGenericType(firstType, secondType);
+        var tuple = Activator.CreateInstance(tupleType, first, second);
+        
+        return tuple;
+    }
+
+    private IntSeq DecodeIntSeq(ref MessagePackReader reader)
+    {
+        var start = reader.ReadInt32();
+        var end = reader.ReadInt32();
+        var step = reader.ReadInt32();
+
+        return new IntSeq(start, end, step);
+    }
+
+    private Regex DecodeRegex(ref MessagePackReader reader)
+    {
+        var pattern = reader.ReadString();
+
+        return new Regex(pattern!);
+    }
+
+    private Class DecodeClass()
+    {
+        return Class.Instance;
+    }
+
+    private TypeAlias DecodeTypeAlias()
+    {
+        return TypeAlias.Instance;
+    }
+
+    private string ToPropertyName(string propertyName)
+    {
+        if (string.IsNullOrEmpty(propertyName))
+        {
+            return propertyName;
+        }
+
+        if (propertyName.Length == 1)
+        {
+            return char.ToUpper(propertyName[0]).ToString();
+        }
+
+        return char.ToUpper(propertyName[0]) + propertyName.Substring(1);;
+    }
+}

--- a/Pkl/Decoder/PklObjectDecoder.cs
+++ b/Pkl/Decoder/PklObjectDecoder.cs
@@ -14,6 +14,8 @@ public partial class Decoder
         return code switch
         {
             PklTypeCode.CodeObject => DecodeObject(ref reader, targetType),
+            PklTypeCode.CodeMap or PklTypeCode.CodeMapping => DecodeMap(ref reader, targetType),
+            PklTypeCode.CodeSet => DecodeSet(ref reader, targetType),
             PklTypeCode.CodeList or PklTypeCode.CodeListing => DecodeCollection(ref reader, targetType),
             PklTypeCode.CodeDataSize => DecodeDataSize(ref reader),
             PklTypeCode.CodeDuration => DecodeDuration(ref reader),

--- a/Pkl/Evaluator/Evaluator.cs
+++ b/Pkl/Evaluator/Evaluator.cs
@@ -19,13 +19,28 @@ public class Evaluator : IEvaluator
         _decoder = decoder;
     }
 
-    public async Task<object> EvaluateExpression(ModuleSource source, string expr)
+    public async Task<T> EvaluateModule<T>(ModuleSource source) where T : notnull
     {
-        var raw = await EvaluateExpressionRaw(source, expr);
-        return _decoder.Decode(raw);
+        return await EvaluateExpression<T>(source, null);
     }
 
-    public async Task<byte[]> EvaluateExpressionRaw(ModuleSource source, string expr)
+    public async Task<string> EvaluateOutputText(ModuleSource source)
+    {
+        return await EvaluateExpression<string>(source, "output.text");
+    }
+
+    public async Task<T> EvaluateOutputValue<T>(ModuleSource source) where T : notnull
+    {
+        return await EvaluateExpression<T>(source, "output.value");
+    }
+
+    public async Task<T> EvaluateExpression<T>(ModuleSource source, string? expr) where T : notnull
+    {
+        var raw = await EvaluateExpressionRaw(source, expr);
+        return _decoder.Decode<T>(raw);
+    }
+
+    public async Task<byte[]> EvaluateExpressionRaw(ModuleSource source, string? expr)
     {
         var evaluate = new Evaluate
         {

--- a/Pkl/Evaluator/IEvaluator.cs
+++ b/Pkl/Evaluator/IEvaluator.cs
@@ -2,7 +2,8 @@ namespace Pkl.Evaluation;
 
 public interface IEvaluator
 {
-    Task<byte[]> EvaluateExpressionRaw(ModuleSource source, string expr);
-
-    Task<object> EvaluateExpression(ModuleSource source, string expr); // TODO define a return type
+    Task<T> EvaluateModule<T>(ModuleSource source) where T : notnull;
+    Task<string> EvaluateOutputText(ModuleSource source);
+    Task<T> EvaluateOutputValue<T>(ModuleSource source) where T : notnull;
+    Task<T> EvaluateExpression<T>(ModuleSource source, string? expr) where T : notnull;
 }

--- a/Pkl/PklTypes/Class.cs
+++ b/Pkl/PklTypes/Class.cs
@@ -1,0 +1,6 @@
+namespace Pkl.PklTypes;
+
+public class Class
+{
+    public static Class Instance { get; } = new();
+}

--- a/Pkl/PklTypes/DataSize.cs
+++ b/Pkl/PklTypes/DataSize.cs
@@ -1,0 +1,14 @@
+namespace Pkl.PklTypes;
+
+public class DataSize
+{
+    public DataSize(DataSizeUnit unit, double value)
+    {
+        Unit = unit;
+        Value = value;
+    }
+
+    public DataSizeUnit Unit { get; set; }
+    
+    public double Value { get; set; }
+}

--- a/Pkl/PklTypes/DataSize.cs
+++ b/Pkl/PklTypes/DataSize.cs
@@ -1,6 +1,6 @@
 namespace Pkl.PklTypes;
 
-public class DataSize
+public struct DataSize
 {
     public DataSize(DataSizeUnit unit, double value)
     {

--- a/Pkl/PklTypes/DataSizeUnit.cs
+++ b/Pkl/PklTypes/DataSizeUnit.cs
@@ -1,0 +1,16 @@
+namespace Pkl.PklTypes;
+
+public enum DataSizeUnit : long
+{
+    Bytes = 1,
+    Kilobytes = 1000,
+    Kibibytes = 1024,
+    Megabytes = Kilobytes * 1000,
+    Mebibytes = Kibibytes * 1024,
+    Gigabytes = Megabytes * 1000,
+    Gibibytes = Mebibytes * 1024,
+    Terabytes = Gigabytes * 1000,
+    Tebibytes = Gibibytes * 1024,
+    Petabytes = Terabytes * 1000,
+    Pebibytes = Tebibytes * 1024
+}

--- a/Pkl/PklTypes/Duration.cs
+++ b/Pkl/PklTypes/Duration.cs
@@ -1,0 +1,30 @@
+namespace Pkl.PklTypes;
+
+public class Duration
+{
+    public Duration(DurationUnit unit, double value)
+    {
+        Unit = unit;
+        Value = value;
+    }
+
+    public DurationUnit Unit { get; set; }
+    
+    public double Value { get; set; }
+
+    public TimeSpan ToTimeSpan()
+    {
+        return Unit switch
+        {
+            DurationUnit.Nanosecond => TimeSpan.FromMicroseconds(Value / 1000),
+            DurationUnit.Microsecond => TimeSpan.FromMicroseconds(Value),
+            DurationUnit.Millisecond => TimeSpan.FromMilliseconds(Value),
+            DurationUnit.Second => TimeSpan.FromSeconds(Value),
+            DurationUnit.Minute => TimeSpan.FromMinutes(Value),
+            DurationUnit.Hour => TimeSpan.FromHours(Value),
+            DurationUnit.Day => TimeSpan.FromDays(Value),
+            
+            _ => throw new NotImplementedException("Unit " + Unit + "is out of range"),
+        };
+    }
+}

--- a/Pkl/PklTypes/Duration.cs
+++ b/Pkl/PklTypes/Duration.cs
@@ -1,6 +1,6 @@
 namespace Pkl.PklTypes;
 
-public class Duration
+public struct Duration
 {
     public Duration(DurationUnit unit, double value)
     {

--- a/Pkl/PklTypes/DurationUnit.cs
+++ b/Pkl/PklTypes/DurationUnit.cs
@@ -1,0 +1,12 @@
+namespace Pkl.PklTypes;
+
+public enum DurationUnit : long
+{
+    Nanosecond = 1,
+    Microsecond = Nanosecond * 1000,
+    Millisecond = Microsecond * 1000,
+    Second = Millisecond * 1000,
+    Minute = Second * 60,
+    Hour = Minute * 60,
+    Day = Hour * 24
+}

--- a/Pkl/PklTypes/IntSeq.cs
+++ b/Pkl/PklTypes/IntSeq.cs
@@ -2,7 +2,7 @@ using System.Collections;
 
 namespace Pkl.PklTypes;
 
-public class IntSeq : IEnumerable<int>
+public struct IntSeq : IEnumerable<int>
 {
     public IntSeq(int start, int end, int step)
     {

--- a/Pkl/PklTypes/IntSeq.cs
+++ b/Pkl/PklTypes/IntSeq.cs
@@ -1,6 +1,8 @@
+using System.Collections;
+
 namespace Pkl.PklTypes;
 
-public class IntSeq
+public class IntSeq : IEnumerable<int>
 {
     public IntSeq(int start, int end, int step)
     {
@@ -13,11 +15,16 @@ public class IntSeq
     public int End { get; set; }
     public int Step { get; set; }
 
-    public IEnumerable<int> Enumerate()
+    public IEnumerator<int> GetEnumerator()
     {
         for (int i = Start; (Step > 0 && i <= End) || (Step < 0 && i >= End); i += Step)
         {
             yield return i;
         }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
     }
 }

--- a/Pkl/PklTypes/IntSeq.cs
+++ b/Pkl/PklTypes/IntSeq.cs
@@ -1,0 +1,23 @@
+namespace Pkl.PklTypes;
+
+public class IntSeq
+{
+    public IntSeq(int start, int end, int step)
+    {
+        Start = start;
+        End = end;
+        Step = step;
+    }
+
+    public int Start { get; set; }
+    public int End { get; set; }
+    public int Step { get; set; }
+
+    public IEnumerable<int> Enumerate()
+    {
+        for (int i = Start; (Step > 0 && i <= End) || (Step < 0 && i >= End); i += Step)
+        {
+            yield return i;
+        }
+    }
+}

--- a/Pkl/PklTypes/TypeAlias.cs
+++ b/Pkl/PklTypes/TypeAlias.cs
@@ -1,0 +1,6 @@
+namespace Pkl.PklTypes;
+
+public class TypeAlias
+{
+    public static TypeAlias Instance { get; } = new();
+}

--- a/PklGenerator/PklSourceGenerator.cs
+++ b/PklGenerator/PklSourceGenerator.cs
@@ -65,7 +65,7 @@ public class PklSourceGenerator : ISourceGenerator
     public class {className}
     {{
         public string Host {{ get; set; }}
-        public string Port {{ get; set; }}
+        public short Port {{ get; set; }}
     }}
 }}";
     }

--- a/Test/Program.cs
+++ b/Test/Program.cs
@@ -1,15 +1,17 @@
+﻿using Pkl;
 using Pkl.Evaluation;
 using Pkl.EvaluatorManager;
 using PklGenerator;
 
-var evaluator = new EvaluatorManager([]);
-var ver = evaluator.GetVersion();
+var manager = new EvaluatorManager([]);
+var ver = manager.GetVersion();
 Console.WriteLine(ver);
-var _ = await evaluator.NewEvaluator(EvaluatorOptions.PreconfiguredOptons());
-evaluator.Close();
+var evaluator = await manager.NewEvaluator(EvaluatorOptions.PreconfiguredOptons());
+var response = await evaluator.EvaluateModule<Test>(ModuleSource.FileSource("Test.pkl"));
+manager.Close();
 
 var temp = new Test
 {
     Host = "https://github.com",
-    Port = "8080"
+    Port = 8080
 };

--- a/Test/Test.pkl
+++ b/Test/Test.pkl
@@ -1,4 +1,4 @@
 typealias Port = UInt16(this > 0)
 
-Host: String = "127.0.0.1"
-Port: Port = 3000
+host: String = "127.0.0.1"
+port: Port = 3000


### PR DESCRIPTION
This PR implements an initial version of the decoder. It decodes the returned PKL objects into an instance of the type passed to Decoder.Evaluate[...].

Things to consider:
- Currently uses reflection to map typed object properties.
- Ends up boxing value types due to returning `object?` from `DecodeAny`.
- ~~Decoding maps is not implemented yet.~~ Maps only decode to Dicionary<K, V> and Lists only decode to T[].

To prevent value types from being boxed and have an alterative to using reflection, I'm thinking of providing an option to use a source generator to generate a custom decoder for each type that maps to a pkl module in the future.