### PR TITLE
Upgrade project to work with pkl version 0.26.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,8 +10,9 @@ jobs:
   build:
     strategy:
       matrix:
-        pklversion: [0.25.2, 0.25.3, 0.26.0]
-    runs-on: ubuntu-latest
+        pklversion: [0.26.0]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - name: Install pkl

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,6 +19,12 @@ jobs:
       uses: pkl-community/setup-pkl@v0
       with:
         pkl-version: ${{ matrix.pklversion }}
+    - name: Debug path
+      if: ${{ runner.os != 'Windows' }}
+      run: echo "$PATH"
+    - name: Debug path
+      if: ${{ runner.os == 'Windows' }}
+      run: echo $env:Path
     - name: pkl cli version
       run: pkl --version
     - name: Setup .NET

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        pklversion: [0.26.0]
+        pklversion: [0.26.0,0.26.1,0.26.2,0.26.3]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,10 +21,14 @@ jobs:
         pkl-version: ${{ matrix.pklversion }}
     - name: Debug path
       if: ${{ runner.os != 'Windows' }}
-      run: echo "$PATH"
+      run: |
+        echo "$PATH"
+        ls -la /opt/hostedtoolcache/pkl/${{ matrix.pklversion }}/x64
     - name: Debug path
       if: ${{ runner.os == 'Windows' }}
-      run: echo $env:Path
+      run: |
+        echo $env:Path
+        ls -la C:\hostedtoolcache\windows\pkl\${{ matrix.pklversion }}\x64
     - name: pkl cli version
       run: pkl --version
     - name: Setup .NET

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,16 +19,6 @@ jobs:
       uses: pkl-community/setup-pkl@v0
       with:
         pkl-version: ${{ matrix.pklversion }}
-    - name: Debug path
-      if: ${{ runner.os != 'Windows' }}
-      run: |
-        echo "$PATH"
-        ls -la /opt/hostedtoolcache/pkl/${{ matrix.pklversion }}/x64
-    - name: Debug path
-      if: ${{ runner.os == 'Windows' }}
-      run: |
-        echo $env:Path
-        Get-ChildItem C:\hostedtoolcache\windows\pkl\${{ matrix.pklversion }}\x64
     - name: pkl cli version
       run: pkl --version
     - name: Setup .NET

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
       if: ${{ runner.os == 'Windows' }}
       run: |
         echo $env:Path
-        ls -la C:\hostedtoolcache\windows\pkl\${{ matrix.pklversion }}\x64
+        Get-ChildItem C:\hostedtoolcache\windows\pkl\${{ matrix.pklversion }}\x64
     - name: pkl cli version
       run: pkl --version
     - name: Setup .NET

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         pklversion: [0.26.0,0.26.1,0.26.2,0.26.3]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/Microsoft.Extensions.Configuration.Pkl/PklCSharp.Microsoft.Extensions.Configuration.csproj
+++ b/Microsoft.Extensions.Configuration.Pkl/PklCSharp.Microsoft.Extensions.Configuration.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <Description>A configuration provider for pkl files.</Description>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Pkl.Tests/Projects/ProjectTests.cs
+++ b/Pkl.Tests/Projects/ProjectTests.cs
@@ -32,6 +32,14 @@ evaluatorSettings {
         ""baz:""
         ""biz:""
     }
+    http {
+        proxy {
+            address = ""http://my.proxy.com:5000""
+            noProxy {
+                ""127.0.0.1""
+            }
+        }
+    }
 }
 
 package {
@@ -106,7 +114,15 @@ package {
             ExternalProperties = new Dictionary<string, string> { { "two", "2" } },
             ModulePath = ["modulepath1/", "modulepath2/"],
             AllowedModules = ["foo:", "bar:"],
-            AllowedResources = ["baz:", "biz:"]
+            AllowedResources = ["baz:", "biz:"],
+            Http = new HttpSettings
+            {
+                Proxy = new ProxySettings
+                {
+                    Address = "http://my.proxy.com:5000",
+                    NoProxy = ["127.0.0.1"]
+                }
+            }
         }, project.EvaluatorSettings);
 
         // Package

--- a/Pkl/Evaluator/EvaluatorOptions.cs
+++ b/Pkl/Evaluator/EvaluatorOptions.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Pkl.InternalMsgApi.Outgoing;
 using Pkl.Projects;
 using Pkl.Reader;
 
@@ -19,6 +20,7 @@ public class EvaluatorOptions
     public string? CacheDir { get; set; }
     public string? RootDir { get; set; }
     public string? ProjectDir { get; set; }
+    public Http? Http { get; set; }
     public ProjectDependencies? DeclaredProjectDependencies { get; set; }
     public ILogger Logger { get; set; } = NullLogger.Instance;
     public Dictionary<string, Type> TypeMappings = new();
@@ -157,6 +159,18 @@ public class EvaluatorOptions
         Properties = project.EvaluatorSettings.ExternalProperties;
         CacheDir = project.EvaluatorSettings.NoCache ? "" : project.EvaluatorSettings.ModuleCacheDir;
         RootDir = project.EvaluatorSettings.RootDir;
+
+        if (project.EvaluatorSettings.Http?.Proxy != null)
+        {
+            Http = new Http
+            {
+                Proxy = new Proxy
+                {
+                    Address = project.EvaluatorSettings.Http.Proxy.Address,
+                    NoProxy = project.EvaluatorSettings.Http.Proxy.NoProxy
+                }
+            };
+        }
 
         if (project.EvaluatorSettings.AllowedModules?.Length > 0)
         {

--- a/Pkl/InternalMsgApi/Outgoing/Implementations/CreateEvaluator.cs
+++ b/Pkl/InternalMsgApi/Outgoing/Implementations/CreateEvaluator.cs
@@ -18,6 +18,7 @@ public class CreateEvaluator : OutgoingMessageBase
         RootDir = options.RootDir;
         OutputFormat = options.OutputFormat;
         Properties = options.Properties;
+        Http = options.Http;
 
         ClientModuleReaders = options.ModuleReaders
             ?.Select(rr => new ModuleReader
@@ -81,6 +82,9 @@ public class CreateEvaluator : OutgoingMessageBase
 
     [Key("project")]
     public ProjectOrDependency? Project { get; set; }
+    
+    [Key("http")]
+    public Http? Http { get; set; }
 
     protected override Code Code { get; set; } = Code.CodeNewEvaluator;
 }
@@ -139,4 +143,24 @@ public class ProjectOrDependency
 
     [Key("dependencies")]
     public Dictionary<string, ProjectOrDependency>? Dependencies { get; set; }
+}
+
+[MessagePackObject]
+public class Http
+{
+    [Key("caCertificates")]
+    public Byte[]? CaCertificates { get; set; }
+    
+    [Key("proxy")]
+    public Proxy? Proxy { get; set; }
+}
+
+[MessagePackObject]
+public class Proxy
+{
+    [Key("address")]
+    public string? Address { get; set; }
+    
+    [Key("noProxy")]
+    public ICollection<string>? NoProxy { get; set; }
 }

--- a/Pkl/Pkl.csproj
+++ b/Pkl/Pkl.csproj
@@ -5,7 +5,7 @@
     <Description>A C# wrapper for the pkl language (https://pkl-lang.org).</Description>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IncludeSymbols>true</IncludeSymbols>

--- a/Pkl/Projects/HttpSettings.cs
+++ b/Pkl/Projects/HttpSettings.cs
@@ -1,0 +1,12 @@
+namespace Pkl.Projects;
+
+public class HttpSettings
+{
+    public ProxySettings? Proxy { get; set; }
+}
+
+public class ProxySettings
+{
+    public string? Address { get; set; }
+    public string[]? NoProxy { get; set; }
+}

--- a/Pkl/Projects/ProjectEvaluatorSettings.cs
+++ b/Pkl/Projects/ProjectEvaluatorSettings.cs
@@ -16,4 +16,5 @@ public class ProjectEvaluatorSettings
     public Duration? Timeout { get; set; }
     public string? ModuleCacheDir { get; set; }
     public string? RootDir { get; set; }
+    public HttpSettings? Http { get; set; }
 }

--- a/PklGenerator.Tests/PklGenerator.Tests.csproj
+++ b/PklGenerator.Tests/PklGenerator.Tests.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
-    <PackageReference Include="xunit" Version="2.4.2"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- This updates the evaluator options to allow providing http options for proxying.
- Updated GitHub action to use all operating system versions