### PR TITLE
Change default executable name when on windows

### DIFF
--- a/Pkl/EvaluatorManager/EvaluatorManager.cs
+++ b/Pkl/EvaluatorManager/EvaluatorManager.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using Pkl.Evaluation;
@@ -51,7 +52,17 @@ public class EvaluatorManager : IEvaluatorManager
             return (cmd, args);
         }
 
-        return ("pkl", " ");
+        return (GetDefaultPklExecutableName(), " ");
+    }
+
+    private string GetDefaultPklExecutableName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "pkl.exe";
+        }
+
+        return "pkl";
     }
 
     private (Process Process, MessagePackStandardOutputReader StdOutputReader) StartProcess() 


### PR DESCRIPTION
This changes the default behavior of `EvaluatorManager` when no pkl executable path is provided.

We used to default to the executable name `pkl`, which was our best guess of the name of pkl's executable in the user's PATH.

When on Windows, I think it would make more sense to add the `.exe` file extension to the file name: `pkl.exe`. Although we can't be sure that the user's PATH will contain an executable named exactly that way, it's serves as a much better guess for the platform.